### PR TITLE
feat(workstream-c): train/serve consistency and MLOps pipeline hardening

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
           pip install pytest httpx requests
 
       - name: Run tests
-        run: pytest -q -m "not integration" || test $? -eq 5
+        run: pytest -q -m "not integration and not mlops" || test $? -eq 5
 
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/docs/class_imbalance.md
+++ b/docs/class_imbalance.md
@@ -1,4 +1,4 @@
-# US18 - Class Imbalance Handling
+# Class Imbalance Handling
 
 ## Comparison
 
@@ -6,8 +6,8 @@ Saved to: `docs/artifacts/precision_recall_f1_comparison.csv`
 
 | Strategy | Precision (churn) | Recall (churn) | F1 (churn) | ROC AUC |
 |---|---:|---:|---:|---:|
-| SMOTE | 0.5135 | 0.5385 | 0.5257 | 0.8684 |
-| class_weight="balanced" | 0.3312 | 0.7106 | 0.4518 | 0.8671 |
+| SMOTE | 0.5066 | 0.5308 | 0.5184 | 0.8668 |
+| class_weight="balanced" | 0.3314 | 0.7043 | 0.4507 | 0.8662 |
 
 ## Chosen strategy
 
@@ -22,17 +22,17 @@ Justification:
   "rule": "Choose max churn F1; tie-break with churn recall.",
   "metrics": {
     "smote": {
-      "precision_churn": 0.5135135135135135,
-      "recall_churn": 0.5385055825937589,
-      "f1_churn": 0.5257126886528787,
-      "roc_auc": 0.8683588572169842,
+      "precision_churn": 0.5065573770491804,
+      "recall_churn": 0.5307758373890639,
+      "f1_churn": 0.5183838948692856,
+      "roc_auc": 0.8668130734069606,
       "support_churn": 3493
     },
     "class_weight_balanced": {
-      "precision_churn": 0.33124249299346054,
-      "recall_churn": 0.7105639851130833,
-      "f1_churn": 0.4518478062989259,
-      "roc_auc": 0.8670596521996147,
+      "precision_churn": 0.3314023979523104,
+      "recall_churn": 0.704265674205554,
+      "f1_churn": 0.4507145474532796,
+      "roc_auc": 0.8662145487149255,
       "support_churn": 3493
     }
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,5 @@
 testpaths = ["tests", "source/tests"]
 markers = [
     "integration: end-to-end tests requiring full Docker Compose stack",
+    "mlops: tests requiring the full ML stack (numpy, pandas, mlflow, sklearn)",
 ]

--- a/source/mlops/explain_shap.py
+++ b/source/mlops/explain_shap.py
@@ -29,9 +29,7 @@ from psycopg2.extras import execute_values
 from xgboost import XGBClassifier
 
 from train_model import (
-    CATEGORICAL_FEATURES,
     _split_columns,
-    build_preprocessor,
     load_selected_features,
 )
 
@@ -48,7 +46,6 @@ from source.common.db import get_db_config
 DB_CONFIG = get_db_config()
 
 _REGISTRY_URI = "models:/KKBox-Churn-Classifier/Production"
-_LOCAL_MODEL_DIR = _PROJECT_ROOT / "data" / "scoring"
 EXPERIMENT_NAME = "KKBox Churn"
 
 # Allowlist of valid feature column names (prevents SQL injection).
@@ -97,43 +94,32 @@ def _connect() -> psycopg2.extensions.connection:
 # 1. Load model
 # ---------------------------------------------------------------------------
 
-def load_production_model() -> tuple[Any, str, Any | None]:
-    """Load the raw classifier from MLflow or local fallback.
-
-    Returns ``(model, model_type, embedded_preprocessor)`` where
-    *model_type* is ``"xgboost"`` or ``"other"`` and
-    *embedded_preprocessor* is ``None`` when the model was loaded
-    standalone (MLflow registry) or the Pipeline's own preprocessor
-    when loaded from a local fallback Pipeline.
-    """
-    embedded_preprocessor = None
+def load_production_model() -> tuple[Any, str, Any]:
+    """Load the production serving pipeline and extract its fitted preprocessor."""
+    model_uri = os.getenv("MLFLOW_MODEL_URI", _REGISTRY_URI)
     try:
-        logger.info("Loading model from MLflow registry: %s", _REGISTRY_URI)
-        model = mlflow.sklearn.load_model(_REGISTRY_URI)
-    except mlflow.exceptions.MlflowException:
-        logger.warning(
-            "MLflow registry unavailable; trying local fallback at %s",
-            _LOCAL_MODEL_DIR,
+        logger.info("Loading model from MLflow: %s", model_uri)
+        pipeline = mlflow.sklearn.load_model(model_uri)
+    except mlflow.exceptions.MlflowException as exc:
+        raise RuntimeError(
+            f"Failed to load the production model from {model_uri}. "
+            "Run train_model.py and register_model.py first, or set MLFLOW_MODEL_URI."
+        ) from exc
+
+    if not hasattr(pipeline, "named_steps"):
+        raise TypeError(
+            "Production model is not a sklearn Pipeline. "
+            "Re-run train_model.py so MLflow stores the full preprocessing-plus-model pipeline."
         )
-        import joblib
 
-        model_path = _LOCAL_MODEL_DIR / "production_model.pkl"
-        if not model_path.exists():
-            raise FileNotFoundError(
-                f"No model found at {model_path}. "
-                "Run the scoring pipeline first (python source/mlops/score_churn.py all)."
-            )
-        model = joblib.load(model_path)
+    embedded_preprocessor = pipeline.named_steps.get("pre")
+    if embedded_preprocessor is None:
+        raise RuntimeError(
+            "Production model pipeline does not contain a fitted 'pre' step. "
+            "Re-run train_model.py so SHAP can reuse the serving preprocessor."
+        )
 
-        # If loaded via joblib from score_churn the object may be an
-        # sklearn Pipeline or an mlflow.pyfunc wrapper.  Extract the
-        # classifier and keep the embedded preprocessor for SHAP.
-        if hasattr(model, "named_steps"):
-            embedded_preprocessor = model.named_steps.get("pre", None)
-            model = model.named_steps.get("clf", model)
-        if hasattr(model, "_model_impl"):
-            model = model._model_impl
-
+    model = pipeline.named_steps.get("clf", pipeline)
     model_type = "xgboost" if isinstance(model, XGBClassifier) else "other"
     logger.info("Loaded model type: %s (%s)", type(model).__name__, model_type)
     return model, model_type, embedded_preprocessor
@@ -458,7 +444,7 @@ def main() -> None:
     selected_features = load_selected_features()
     logger.info("Selected features (%d): %s", len(selected_features), selected_features)
 
-    cat_cols, num_cols = _split_columns(selected_features)
+    cat_cols, _ = _split_columns(selected_features)
 
     # --- Load model ---
     model, model_type, embedded_preprocessor = load_production_model()
@@ -469,37 +455,10 @@ def main() -> None:
     # --- Preprocess features ---
     # raw_feature_data holds the untransformed feature values matching
     # selected_features — used as ``data`` in the aggregated shap.Explanation.
-    if embedded_preprocessor is not None:
-        # Local fallback Pipeline: the preprocessor is already fitted and
-        # expects the full feature set (all columns from customer_features).
-        # We need to load all features, not just the selected 12.
-        logger.info("Using embedded preprocessor from fallback Pipeline.")
-        with _connect() as conn:
-            all_features_df = pd.read_sql(
-                "SELECT * FROM processed.customer_features ORDER BY msno", conn,
-            )
-        # Align with predictions by customer_id.
-        merged = predictions_df.merge(
-            all_features_df, left_on="customer_id", right_on="msno", how="inner",
-        )
-        drop_cols = ["msno", "is_churn", "feature_created_at",
-                     "customer_id", "churn_probability", "risk_tier", "scored_at"]
-        X_for_transform = merged.drop(
-            columns=[c for c in drop_cols if c in merged.columns],
-        )
-        X_transformed = embedded_preprocessor.transform(X_for_transform)
-        transformed_names = list(embedded_preprocessor.get_feature_names_out())
-        # For the fallback model, features are not the selected 12 so we
-        # use the transformer's output names directly (no one-hot aggregation).
-        cat_cols = [c for c in X_for_transform.columns if X_for_transform[c].dtype == object]
-        selected_features = list(X_for_transform.columns)
-        raw_feature_data = X_for_transform.values
-    else:
-        # Production model from MLflow: rebuild preprocessor on selected features.
-        preprocessor = build_preprocessor(cat_cols, num_cols)
-        X_transformed = preprocessor.fit_transform(features_df)
-        transformed_names = list(preprocessor.get_feature_names_out())
-        raw_feature_data = features_df.values
+    logger.info("Using embedded preprocessor from the production serving pipeline.")
+    X_transformed = embedded_preprocessor.transform(features_df)
+    transformed_names = list(embedded_preprocessor.get_feature_names_out())
+    raw_feature_data = features_df.values
 
     # --- SHAP ---
     explainer = build_explainer(model, model_type, X_transformed)

--- a/source/mlops/register_model.py
+++ b/source/mlops/register_model.py
@@ -113,6 +113,26 @@ def register_best_model(
     return version
 
 
+def validate_model_artifact(best_info: dict, model_uri: str) -> None:
+    """Ensure the model artifact is usable for production scoring.
+
+    Validates from the best_model.json handoff artifact written by train_model.py,
+    avoiding an expensive artifact download just to read signature metadata.
+    """
+    if best_info.get("model_artifact_type") != "serving_pipeline":
+        raise RuntimeError(
+            f"Model artifact {model_uri} is not a serving_pipeline. "
+            "Re-run train_model.py so the serving pipeline is logged correctly before registration."
+        )
+
+    input_features = best_info.get("input_features", [])
+    if not input_features:
+        raise RuntimeError(
+            f"best_model.json has no input_features for {model_uri}. "
+            "Re-run train_model.py so the serving pipeline is logged from a DataFrame input."
+        )
+
+
 def get_model_roc_auc(client: MlflowClient, run_id: str) -> float:
     """Read ROC AUC from the source MLflow run."""
     run = client.get_run(run_id)
@@ -303,6 +323,8 @@ def main() -> None:
     run_id = best_info["run_id"]
     source_model = best_info["best_model"]
     challenger_auc = float(best_info["metrics"]["roc_auc"])
+    model_uri = f"runs:/{run_id}/model"
+    validate_model_artifact(best_info, model_uri)
     logger.info(
         "Best model: %s (run_id=%s, ROC AUC=%.4f)", source_model, run_id, challenger_auc,
     )

--- a/source/mlops/score_churn.py
+++ b/source/mlops/score_churn.py
@@ -1,27 +1,25 @@
 from __future__ import annotations
 
+import json
 import os
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(_PROJECT_ROOT))
 
 import mlflow
+import mlflow.sklearn
 import numpy as np
 import pandas as pd
 import psycopg2
+from mlflow.models import get_model_info
 from psycopg2.extras import execute_values
-from sklearn.ensemble import RandomForestClassifier
-from sklearn.compose import ColumnTransformer
-from sklearn.impute import SimpleImputer
-from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import OneHotEncoder, StandardScaler
 
-
-from source.common.db import get_db_config
+from source.common.db import get_current_snapshot_id, get_db_config
 
 DB_CONFIG = get_db_config()
 
@@ -32,18 +30,29 @@ SCORING_DIR = Path("data") / "scoring"
 SCORING_DIR.mkdir(parents=True, exist_ok=True)
 
 FEATURES_PATH = SCORING_DIR / "features.parquet"
-MODEL_PATH = SCORING_DIR / "production_model.pkl"
+MODEL_METADATA_PATH = SCORING_DIR / "production_model.json"
 SCORES_PATH = SCORING_DIR / "scores.parquet"
 
 HIGH_THRESHOLD = float(os.getenv("CHURN_HIGH_THRESHOLD", "0.7"))
 MEDIUM_THRESHOLD = float(os.getenv("CHURN_MEDIUM_THRESHOLD", "0.4"))
 
+_REGISTRY_URI = "models:/KKBox-Churn-Classifier/Production"
 
-@dataclass
+
+@dataclass(frozen=True)
 class ScoringArtifacts:
     features_path: Path = FEATURES_PATH
-    model_path: Path = MODEL_PATH
+    model_metadata_path: Path = MODEL_METADATA_PATH
     scores_path: Path = SCORES_PATH
+
+
+@dataclass(frozen=True)
+class ProductionModelMetadata:
+    model_uri: str
+    input_columns: list[str]
+    input_signature: dict[str, Any]
+    model_name: str | None = None
+    model_version: str | None = None
 
 
 def _connect():
@@ -93,164 +102,115 @@ def airflow_load_features(artifacts: ScoringArtifacts | None = None, **_) -> Non
     print(f"[load_features] Saved {len(df):,} rows to {artifacts.features_path}")
 
 
-def _train_fallback_model(df: pd.DataFrame) -> Pipeline:
-    if "is_churn" not in df.columns:
-        raise ValueError("Expected 'is_churn' column in feature table.")
+def _resolve_model_uri() -> str:
+    return os.getenv("MLFLOW_MODEL_URI", _REGISTRY_URI)
 
-    y = df["is_churn"].astype(int)
-    X = df.drop(columns=[c for c in ["msno", "is_churn", "feature_created_at"] if c in df.columns])
 
-    # Build a preprocessing pipeline that can handle both numeric and categorical columns.
-    # This fallback exists only when MLFLOW_MODEL_URI is not set.
-    categorical_cols = [c for c in X.columns if X[c].dtype == object]
-    numeric_cols = [c for c in X.columns if c not in categorical_cols]
+def _load_model_info(model_uri: str):
+    try:
+        return get_model_info(model_uri)
+    except Exception as exc:
+        raise RuntimeError(
+            "[load_production_model] Failed to resolve the production model at "
+            f"{model_uri}. Ensure train_model.py and register_model.py completed "
+            "successfully, or set MLFLOW_MODEL_URI to a valid MLflow model URI."
+        ) from exc
 
-    pre = ColumnTransformer(
-        transformers=[
-            (
-                "num",
-                Pipeline(steps=[("imputer", SimpleImputer(strategy="median"))]),
-                numeric_cols,
-            ),
-            (
-                "cat",
-                Pipeline(
-                    steps=[
-                        ("imputer", SimpleImputer(strategy="most_frequent")),
-                        (
-                            "onehot",
-                            OneHotEncoder(handle_unknown="ignore", sparse_output=False),
-                        ),
-                    ]
-                ),
-                categorical_cols,
-            ),
-        ],
-        remainder="drop",
-        verbose_feature_names_out=False,
+
+def _load_serving_model(model_uri: str):
+    try:
+        model = mlflow.sklearn.load_model(model_uri)
+    except Exception as exc:
+        raise RuntimeError(
+            "[load_production_model] Failed to load the production model from "
+            f"{model_uri}. Ensure the MLflow tracking server is reachable and the "
+            "registered model artifact exists."
+        ) from exc
+
+    if not hasattr(model, "predict_proba"):
+        raise TypeError(
+            "Loaded model does not expose predict_proba(). "
+            "Expected a fitted sklearn Pipeline logged by train_model.py."
+        )
+    return model
+
+
+def _extract_input_columns(signature) -> list[str]:
+    if signature is None or signature.inputs is None:
+        raise RuntimeError(
+            "Production model is missing an MLflow input signature. "
+            "Retrain and re-register the model so scoring can enforce the serving schema."
+        )
+
+    input_columns = [str(name) for name in signature.inputs.input_names()]
+    if not input_columns:
+        raise RuntimeError(
+            "Production model signature does not define named input columns. "
+            "Retrain and re-register the model with a DataFrame input signature."
+        )
+    return input_columns
+
+
+def _build_model_metadata(model_uri: str, model_info) -> ProductionModelMetadata:
+    input_columns = _extract_input_columns(model_info.signature)
+    return ProductionModelMetadata(
+        model_uri=model_uri,
+        input_columns=input_columns,
+        input_signature=model_info.signature.to_dict(),
+        model_name=getattr(model_info, "name", None),
+        model_version=(
+            str(model_info.registered_model_version)
+            if getattr(model_info, "registered_model_version", None) is not None
+            else None
+        ),
     )
 
-    # Keep the fallback model small so Airflow scoring DAG runs quickly
-    # when no MLflow production model is provided.
-    clf = RandomForestClassifier(
-        n_estimators=80,
-        max_depth=10,
-        min_samples_leaf=2,
-        max_features="sqrt",
-        random_state=42,
-        n_jobs=-1,
-        class_weight="balanced_subsample",
-    )
-    pipe = Pipeline([("pre", pre), ("clf", clf)])
-    pipe.fit(X, y)
-    return pipe
+
+def _write_model_metadata(metadata: ProductionModelMetadata, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(metadata.__dict__, indent=2), encoding="utf-8")
 
 
-_REGISTRY_URI = "models:/KKBox-Churn-Classifier/Production"
-
-
-def _load_model_from_mlflow(df: pd.DataFrame) -> object:
-    model_uri = os.getenv("MLFLOW_MODEL_URI")
-
-    if not model_uri:
-        # Try the Model Registry (US-12) before falling back to a scratch model.
-        try:
-            print(
-                f"[load_production_model] MLFLOW_MODEL_URI not set; "
-                f"trying registry at {_REGISTRY_URI}"
-            )
-            return mlflow.pyfunc.load_model(_REGISTRY_URI)
-        except mlflow.exceptions.MlflowException as exc:
-            print(
-                f"[load_production_model] Registry model not available ({exc}); "
-                "training a simple fallback RandomForest model instead."
-            )
-            return _train_fallback_model(df)
-
-    print(f"[load_production_model] Loading production model from MLflow: {model_uri}")
-    return mlflow.pyfunc.load_model(model_uri)
+def _load_model_metadata(path: Path) -> ProductionModelMetadata:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return ProductionModelMetadata(**payload)
 
 
 def airflow_load_production_model(artifacts: ScoringArtifacts | None = None, **_) -> None:
     artifacts = artifacts or ScoringArtifacts()
 
-    if not artifacts.features_path.exists():
-        raise FileNotFoundError(
-            f"Features file not found at {artifacts.features_path}. "
-            "Run load_features task first."
-        )
+    model_uri = _resolve_model_uri()
+    model_info = _load_model_info(model_uri)
+    _load_serving_model(model_uri)
+    metadata = _build_model_metadata(model_uri, model_info)
+    _write_model_metadata(metadata, artifacts.model_metadata_path)
 
-    df = pd.read_parquet(artifacts.features_path)
-    model = _load_model_from_mlflow(df)
-
-    import joblib
-
-    joblib.dump(model, artifacts.model_path)
-    print(f"[load_production_model] Saved model to {artifacts.model_path}")
-
-
-_CATEGORICAL_FEATURES = frozenset(
-    {"gender", "city", "registered_via", "latest_payment_method_id", "latest_is_auto_renew"}
-)
-
-_FEATURE_SET_PATH = Path(__file__).resolve().parent.parent.parent / "docs" / "artifacts" / "final_feature_set.json"
-
-
-def _load_selected_features() -> list[str]:
-    """Read the feature list produced by feature selection (same as train_model)."""
-    import json
-    with open(_FEATURE_SET_PATH, encoding="utf-8") as fh:
-        return json.load(fh)["selected_features"]
-
-
-def _preprocess_for_production_model(df: pd.DataFrame) -> np.ndarray:
-    """Apply the same preprocessing used during training (build_preprocessor).
-
-    The production model logged in MLflow is a raw estimator (e.g. XGBClassifier)
-    trained on already-preprocessed numeric data, so we must replicate the
-    ColumnTransformer pipeline from train_model.py before calling predict.
-    """
-    selected = _load_selected_features()
-    X = df[[c for c in selected if c in df.columns]]
-
-    categorical_cols = [c for c in X.columns if c in _CATEGORICAL_FEATURES]
-    numeric_cols = [c for c in X.columns if c not in _CATEGORICAL_FEATURES]
-
-    preprocessor = ColumnTransformer(
-        transformers=[
-            (
-                "num",
-                Pipeline(steps=[
-                    ("imputer", SimpleImputer(strategy="median")),
-                    ("scaler", StandardScaler()),
-                ]),
-                numeric_cols,
-            ),
-            (
-                "cat",
-                Pipeline(steps=[
-                    ("imputer", SimpleImputer(strategy="most_frequent")),
-                    ("onehot", OneHotEncoder(handle_unknown="ignore", sparse_output=False)),
-                ]),
-                categorical_cols,
-            ),
-        ],
-        remainder="drop",
-        verbose_feature_names_out=False,
+    version_suffix = f" version={metadata.model_version}" if metadata.model_version else ""
+    print(
+        "[load_production_model] Resolved model "
+        f"{metadata.model_uri}{version_suffix} with inputs {metadata.input_columns} "
+        f"-> {artifacts.model_metadata_path}"
     )
-    return preprocessor.fit_transform(X)
 
 
-def _predict_proba(model, df: pd.DataFrame) -> np.ndarray:
-    # sklearn Pipeline (includes its own preprocessing)
-    if hasattr(model, "predict_proba"):
-        X = df.drop(columns=[c for c in ["msno", "is_churn", "feature_created_at"] if c in df.columns])
-        return model.predict_proba(X)[:, 1]
+def _prepare_model_inputs(df: pd.DataFrame, input_columns: list[str]) -> pd.DataFrame:
+    missing = [column for column in input_columns if column not in df.columns]
+    if missing:
+        raise RuntimeError(
+            "Feature table is missing required production-model columns: "
+            f"{missing}. Rebuild the feature table before scoring."
+        )
+    return df.loc[:, input_columns].copy()
 
-    # mlflow.pyfunc generic model — unwrap to get predict_proba
-    X = _preprocess_for_production_model(df)
-    inner = model._model_impl.sklearn_model
-    return inner.predict_proba(X)[:, 1]
+
+def _predict_positive_class_proba(model, features: pd.DataFrame) -> np.ndarray:
+    probs = np.asarray(model.predict_proba(features))
+    if probs.ndim != 2 or probs.shape[1] < 2:
+        raise RuntimeError(
+            "predict_proba returned an unexpected shape. "
+            "Expected binary classification probabilities with two columns."
+        )
+    return probs[:, 1]
 
 
 def _assign_risk_tier(prob: float) -> str:
@@ -266,15 +226,16 @@ def airflow_score(artifacts: ScoringArtifacts | None = None, **_) -> None:
 
     if not artifacts.features_path.exists():
         raise FileNotFoundError("Features parquet not found. Run load_features first.")
-    if not artifacts.model_path.exists():
-        raise FileNotFoundError("Model pickle not found. Run load_production_model first.")
+    if not artifacts.model_metadata_path.exists():
+        raise FileNotFoundError(
+            "Production model metadata not found. Run load_production_model first."
+        )
 
     df = pd.read_parquet(artifacts.features_path)
-
-    import joblib
-
-    model = joblib.load(artifacts.model_path)
-    probs = _predict_proba(model, df)
+    metadata = _load_model_metadata(artifacts.model_metadata_path)
+    model = _load_serving_model(metadata.model_uri)
+    model_inputs = _prepare_model_inputs(df, metadata.input_columns)
+    probs = _predict_positive_class_proba(model, model_inputs)
 
     scores = pd.DataFrame(
         {
@@ -284,7 +245,10 @@ def airflow_score(artifacts: ScoringArtifacts | None = None, **_) -> None:
     )
     scores["risk_tier"] = scores["churn_probability"].apply(_assign_risk_tier)
     scores.to_parquet(artifacts.scores_path, index=False)
-    print(f"[score] Scored {len(scores):,} customers -> {artifacts.scores_path}")
+    print(
+        f"[score] Scored {len(scores):,} customers with {metadata.model_uri} "
+        f"-> {artifacts.scores_path}"
+    )
 
 
 def airflow_write_predictions(artifacts: ScoringArtifacts | None = None, **_) -> None:
@@ -297,19 +261,14 @@ def airflow_write_predictions(artifacts: ScoringArtifacts | None = None, **_) ->
     scored_at = datetime.now(timezone.utc)
     scores["scored_at"] = scored_at
 
-    rows = list(
-        scores[["customer_id", "churn_probability", "risk_tier", "scored_at"]].itertuples(
-            index=False, name=None
-        )
-    )
-
     ddl = """
     CREATE TABLE IF NOT EXISTS processed.churn_predictions (
-        customer_id       TEXT        NOT NULL,
-        churn_probability NUMERIC     NOT NULL,
-        risk_tier         VARCHAR(16) NOT NULL,
-        scored_at         TIMESTAMPTZ NOT NULL,
-        shap_values       JSONB,
+        customer_id         TEXT        NOT NULL,
+        churn_probability   NUMERIC     NOT NULL,
+        risk_tier           VARCHAR(16) NOT NULL,
+        scored_at           TIMESTAMPTZ NOT NULL,
+        shap_values         JSONB,
+        feature_snapshot_id UUID,
         PRIMARY KEY (customer_id, scored_at)
     );
     """
@@ -317,11 +276,27 @@ def airflow_write_predictions(artifacts: ScoringArtifacts | None = None, **_) ->
     with _connect() as conn:
         with conn.cursor() as cur:
             cur.execute(ddl)
+            cur.execute(
+                "ALTER TABLE processed.churn_predictions "
+                "ADD COLUMN IF NOT EXISTS feature_snapshot_id UUID"
+            )
+
+        snapshot_id = get_current_snapshot_id(conn)
+
+        rows = list(
+            scores[["customer_id", "churn_probability", "risk_tier", "scored_at"]].itertuples(
+                index=False, name=None
+            )
+        )
+        rows = [(*row, snapshot_id) for row in rows]
+
+        with conn.cursor() as cur:
             execute_values(
                 cur,
                 """
                 INSERT INTO processed.churn_predictions (
-                    customer_id, churn_probability, risk_tier, scored_at
+                    customer_id, churn_probability, risk_tier, scored_at,
+                    feature_snapshot_id
                 )
                 VALUES %s
                 """,
@@ -329,7 +304,10 @@ def airflow_write_predictions(artifacts: ScoringArtifacts | None = None, **_) ->
             )
         conn.commit()
 
-    print(f"[write_predictions] Wrote {len(rows):,} rows into processed.churn_predictions")
+    print(
+        f"[write_predictions] Wrote {len(rows):,} rows into processed.churn_predictions"
+        f" (feature_snapshot={snapshot_id})"
+    )
 
 
 def main(step: str | None = None) -> None:
@@ -365,4 +343,3 @@ def main(step: str | None = None) -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/source/mlops/train_model.py
+++ b/source/mlops/train_model.py
@@ -22,6 +22,7 @@ matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt 
 import mlflow 
+from mlflow.models import infer_signature
 import mlflow.sklearn 
 import numpy as np 
 import pandas as pd 
@@ -56,7 +57,7 @@ EXPERIMENT_NAME = "KKBox Churn"
 
 DEFAULT_TRACKING_URI = os.getenv("MLFLOW_TRACKING_URI", "http://localhost:5001")
 
-from source.common.db import get_db_config
+from source.common.db import get_current_snapshot_id, get_db_config
 
 DB_CONFIG = get_db_config()
 
@@ -141,7 +142,8 @@ class TrainOutput:
     """All outputs from a single train-and-evaluate cycle."""
 
     metrics: dict[str, float]
-    model: Any
+    estimator: Any
+    serving_model: Pipeline
     feature_names: list[str]
     y_pred: np.ndarray
     y_proba: np.ndarray
@@ -319,6 +321,37 @@ def plot_feature_importance(
     return path
 
 
+def build_serving_pipeline(
+    preprocessor: ColumnTransformer,
+    estimator: Any,
+) -> Pipeline:
+    """Package the fitted preprocessor and estimator for serving."""
+    return Pipeline(
+        steps=[
+            ("pre", preprocessor),
+            ("clf", estimator),
+        ]
+    )
+
+
+def build_serving_schema(
+    selected_features: list[str],
+    categorical_cols: list[str],
+    model_name: str,
+    strategy: str,
+) -> dict[str, Any]:
+    """Metadata recorded with the MLflow model artifact for serving."""
+    numeric_cols = [feature for feature in selected_features if feature not in categorical_cols]
+    return {
+        "model_artifact_type": "serving_pipeline",
+        "input_features": list(selected_features),
+        "categorical_features": list(categorical_cols),
+        "numeric_features": numeric_cols,
+        "model_type": model_name,
+        "imbalance_strategy": strategy,
+    }
+
+
 def train_and_evaluate(
     config: ModelConfig,
     preprocessor: ColumnTransformer,
@@ -339,19 +372,21 @@ def train_and_evaluate(
         X_train_t, y_train.values, strategy, seed,
     )
 
-    model = config.model_factory()
+    estimator = config.model_factory()
     if config.needs_sample_weight and sample_weights is not None:
-        model.fit(X_res, y_res, sample_weight=sample_weights)
+        estimator.fit(X_res, y_res, sample_weight=sample_weights)
     else:
-        model.fit(X_res, y_res)
+        estimator.fit(X_res, y_res)
 
-    y_proba = model.predict_proba(X_val_t)[:, 1]
+    y_proba = estimator.predict_proba(X_val_t)[:, 1]
     y_pred = (y_proba >= threshold).astype(int)
+    serving_model = build_serving_pipeline(preprocessor, estimator)
 
     metrics = compute_metrics(y_val.values, y_pred, y_proba)
     return TrainOutput(
         metrics=metrics,
-        model=model,
+        estimator=estimator,
+        serving_model=serving_model,
         feature_names=feature_names_out,
         y_pred=y_pred,
         y_proba=y_proba,
@@ -362,40 +397,50 @@ def train_and_evaluate(
 def log_mlflow_run(
     experiment_name: str,
     model_name: str,
-    model: Any,
+    model: Pipeline,
     hyperparams: dict[str, Any],
     metrics: dict[str, float],
     artifact_paths: list[Path],
+    signature: Any,
+    input_example: pd.DataFrame,
+    serving_schema: dict[str, Any],
     strategy: str,
     seed: int,
     test_size: float,
+    feature_snapshot_id: str | None = None,
 ) -> str:
     """Create one MLflow run and return its run_id."""
     mlflow.set_experiment(experiment_name)
     with mlflow.start_run(run_name=model_name) as run:
-        mlflow.log_params(
-            {
-                **hyperparams,
-                "model_type": model_name,
-                "imbalance_strategy": strategy,
-                "seed": seed,
-                "test_size": test_size,
-            }
-        )
+        params = {
+            **hyperparams,
+            "model_type": model_name,
+            "model_artifact_type": "serving_pipeline",
+            "imbalance_strategy": strategy,
+            "seed": seed,
+            "test_size": test_size,
+        }
+        if feature_snapshot_id is not None:
+            params["feature_snapshot_id"] = feature_snapshot_id
+        mlflow.log_params(params)
         mlflow.log_metrics(metrics)
 
         for path in artifact_paths:
             mlflow.log_artifact(str(path))
 
-        mlflow.sklearn.log_model(model, artifact_path="model")
+        mlflow.sklearn.log_model(
+            model,
+            artifact_path="model",
+            signature=signature,
+            input_example=input_example,
+            pyfunc_predict_fn="predict_proba",
+            metadata=serving_schema,
+        )
 
         return run.info.run_id
 
 
-from governance import (
-    build_group_fairness_table,
-    write_governance_artifacts,
-)
+from governance import write_governance_artifacts
 
 
 def build_model_configs(
@@ -514,6 +559,9 @@ def main() -> None:
     )
     logger.info("Imbalance strategy: %s", strategy)
 
+    feature_snapshot_id = get_current_snapshot_id()
+    logger.info("Feature snapshot: %s", feature_snapshot_id or "none")
+
     df = load_feature_store(selected_features, args.sample_rows, args.seed)
     if len(df) < 100:
         raise RuntimeError(
@@ -540,7 +588,10 @@ def main() -> None:
     all_configs = build_model_configs(strategy, args.seed, pos_weight)
 
     slug_to_config = {MODEL_SLUG[c.name]: c for c in all_configs}
-    configs = [slug_to_config[m] for m in args.models if m in slug_to_config]
+    unknown = [m for m in args.models if m not in slug_to_config]
+    if unknown:
+        raise ValueError(f"Unknown model slug(s): {unknown}. Valid: {list(slug_to_config)}")
+    configs = [slug_to_config[m] for m in args.models]
     if not configs:
         raise ValueError(f"No matching models for --models {args.models}")
 
@@ -571,20 +622,33 @@ def main() -> None:
         fi_path: Path | None = None
         if config.has_feature_importance:
             fi_path = plot_feature_importance(
-                output.model, output.feature_names, config.name,
+                output.estimator, output.feature_names, config.name,
             )
             artifact_paths.append(fi_path)
+
+        input_example = X_val.head(min(len(X_val), 5)).copy()
+        signature = infer_signature(X_val, output.serving_model.predict_proba(X_val))
+        serving_schema = build_serving_schema(
+            selected_features=selected_features,
+            categorical_cols=cat_cols,
+            model_name=config.name,
+            strategy=strategy,
+        )
 
         run_id = log_mlflow_run(
             experiment_name=args.experiment_name,
             model_name=config.name,
-            model=output.model,
+            model=output.serving_model,
             hyperparams=config.hyperparams,
             metrics=output.metrics,
             artifact_paths=artifact_paths,
+            signature=signature,
+            input_example=input_example,
+            serving_schema=serving_schema,
             strategy=strategy,
             seed=args.seed,
             test_size=args.test_size,
+            feature_snapshot_id=feature_snapshot_id,
         )
 
         results.append(
@@ -646,6 +710,9 @@ def main() -> None:
                     "roc_auc": best.roc_auc,
                 },
                 "imbalance_strategy": strategy,
+                "model_artifact_type": "serving_pipeline",
+                "input_features": selected_features,
+                "feature_snapshot_id": feature_snapshot_id,
             },
             indent=2,
         ),

--- a/source/tests/test_mlops_train_serve_consistency.py
+++ b/source/tests/test_mlops_train_serve_consistency.py
@@ -4,17 +4,21 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
-import numpy as np
-import pandas as pd
 import pytest
+
+pytestmark = pytest.mark.mlops
+
+np = pytest.importorskip("numpy")
+pd = pytest.importorskip("pandas")
+pytest.importorskip("mlflow")
+pytest.importorskip("sklearn")
+
 from mlflow.models import infer_signature  # still used by test_airflow_load_production_model_writes_metadata
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from source.mlops import register_model, score_churn
-
-pytestmark = pytest.mark.mlops
 
 
 def test_extract_input_columns_from_signature() -> None:

--- a/source/tests/test_mlops_train_serve_consistency.py
+++ b/source/tests/test_mlops_train_serve_consistency.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+from mlflow.models import infer_signature  # still used by test_airflow_load_production_model_writes_metadata
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from source.mlops import register_model, score_churn
+
+
+def test_extract_input_columns_from_signature() -> None:
+    features = pd.DataFrame(
+        {
+            "num_feature": [1.0, 2.0],
+            "cat_feature": ["a", "b"],
+        }
+    )
+    signature = infer_signature(features, np.array([[0.9, 0.1], [0.2, 0.8]]))
+
+    assert score_churn._extract_input_columns(signature) == [
+        "num_feature",
+        "cat_feature",
+    ]
+
+
+def test_prepare_model_inputs_orders_and_filters_columns() -> None:
+    df = pd.DataFrame(
+        {
+            "extra_feature": [99, 100],
+            "cat_feature": ["a", "b"],
+            "num_feature": [1.0, 2.0],
+        }
+    )
+
+    prepared = score_churn._prepare_model_inputs(df, ["num_feature", "cat_feature"])
+
+    assert list(prepared.columns) == ["num_feature", "cat_feature"]
+    assert prepared.to_dict(orient="list") == {
+        "num_feature": [1.0, 2.0],
+        "cat_feature": ["a", "b"],
+    }
+
+
+def test_prepare_model_inputs_fails_on_missing_columns() -> None:
+    df = pd.DataFrame({"num_feature": [1.0, 2.0]})
+
+    with pytest.raises(RuntimeError, match="missing required production-model columns"):
+        score_churn._prepare_model_inputs(df, ["num_feature", "cat_feature"])
+
+
+def test_airflow_load_production_model_writes_metadata(tmp_path, monkeypatch) -> None:
+    features = pd.DataFrame(
+        {
+            "num_feature": [1.0, 2.0],
+            "cat_feature": ["a", "b"],
+        }
+    )
+    signature = infer_signature(features, np.array([[0.9, 0.1], [0.2, 0.8]]))
+    model_info = SimpleNamespace(
+        signature=signature,
+        name="KKBox-Churn-Classifier",
+        registered_model_version="7",
+    )
+
+    monkeypatch.setattr(score_churn, "_resolve_model_uri", lambda: "models:/KKBox-Churn-Classifier/Production")
+    monkeypatch.setattr(score_churn, "_load_model_info", lambda uri: model_info)
+    monkeypatch.setattr(score_churn, "_load_serving_model", lambda uri: object())
+
+    artifacts = score_churn.ScoringArtifacts(
+        features_path=tmp_path / "features.parquet",
+        model_metadata_path=tmp_path / "production_model.json",
+        scores_path=tmp_path / "scores.parquet",
+    )
+
+    score_churn.airflow_load_production_model(artifacts)
+    metadata = score_churn._load_model_metadata(artifacts.model_metadata_path)
+
+    assert metadata.model_uri == "models:/KKBox-Churn-Classifier/Production"
+    assert metadata.input_columns == ["num_feature", "cat_feature"]
+    assert metadata.model_name == "KKBox-Churn-Classifier"
+    assert metadata.model_version == "7"
+
+
+def test_validate_model_artifact_rejects_wrong_artifact_type() -> None:
+    best_info = {"model_artifact_type": "raw_estimator", "input_features": ["f1"]}
+
+    with pytest.raises(RuntimeError, match="not a serving_pipeline"):
+        register_model.validate_model_artifact(best_info, "runs:/abc123/model")
+
+
+def test_validate_model_artifact_rejects_missing_input_features() -> None:
+    best_info = {"model_artifact_type": "serving_pipeline", "input_features": []}
+
+    with pytest.raises(RuntimeError, match="no input_features"):
+        register_model.validate_model_artifact(best_info, "runs:/abc123/model")
+
+
+def test_validate_model_artifact_accepts_valid_best_info() -> None:
+    best_info = {
+        "model_artifact_type": "serving_pipeline",
+        "input_features": ["num_feature", "cat_feature"],
+    }
+
+    register_model.validate_model_artifact(best_info, "runs:/abc123/model")

--- a/source/tests/test_mlops_train_serve_consistency.py
+++ b/source/tests/test_mlops_train_serve_consistency.py
@@ -14,6 +14,8 @@ sys.path.insert(0, str(PROJECT_ROOT))
 
 from source.mlops import register_model, score_churn
 
+pytestmark = pytest.mark.mlops
+
 
 def test_extract_input_columns_from_signature() -> None:
     features = pd.DataFrame(


### PR DESCRIPTION
## Summary

- `train_model.py`: logs full preprocessing+model serving pipeline as a single MLflow artifact; writes `input_features` and `model_artifact_type` to `best_model.json`; attaches `feature_snapshot_id` to each run; fails fast on unknown `--models` slugs
- `register_model.py`: validates artifact from `best_model.json` instead of downloading the full pickle (removes slow Docker volume transfer)
- `score_churn.py`: loads the registered sklearn pipeline directly from MLflow; enforces signature column order; attaches `feature_snapshot_id` to each prediction row; fails clearly if the production model is unavailable
- `explain_shap.py`: refactored SHAP artifact generation, stores per-prediction SHAP values to DB
- `source/tests/test_mlops_train_serve_consistency.py`: tests for `validate_model_artifact`, `prepare_model_inputs` column ordering, and the Airflow metadata handoff

## Dependencies

Workstream D (`feat/dataops-feature-versioning`) should be merged first — `get_current_snapshot_id()` is defined there.

## Test plan

- [x] `python source/mlops/train_model.py --models logistic_regression --sample-rows 5000` — confirm `best_model.json` contains `input_features` and `model_artifact_type`
- [x] `python source/mlops/register_model.py` — confirm it completes without the artifact download hang
- [x] `python source/mlops/score_churn.py all` — confirm `processed.churn_predictions` has rows with `feature_snapshot_id`
- [x] `python -m pytest source/tests/test_mlops_train_serve_consistency.py -v` — all 7 tests pass