### PR TITLE
feat(workstream-f): monitoring and promotion quality hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,82 @@ WHERE feature_snapshot_id IS NOT NULL;
 
 ---
 
+### Step 18 — Monitoring & promotion quality (Workstream F)
+
+Workstream F hardens the monitoring and champion-challenger flows:
+
+- **Provenance on every prediction** — `processed.churn_predictions` now records `model_version` (from the MLflow registry) and `threshold_version` (the classification policy, currently `v1` at 0.5) alongside `feature_snapshot_id`.
+- **Calibration + score distribution** — the weekly monitoring DAG now computes reliability bins, Brier score, max calibration error, and 10-bucket probability distribution per run.
+- **Segment-level drift** — PSI is now computed per segment (split by `latest_is_auto_renew` and derived `has_cancel_history`) in addition to feature-level drift.
+- **Minimum-sample guard** — when the labelled current window has fewer than `MONITORING_MIN_SAMPLES` rows (default `1000`) the run is recorded with `status='insufficient_data'` and the retraining DAG is skipped. Prevents retraining on noisy, sparse windows.
+- **Business-metric promotion gate** — `register_model.py` now requires both an AUC improvement AND no regression on a business metric (default `precision_churn`) beyond `BUSINESS_METRIC_TOLERANCE` (default `0.01`). Regressions produce the new decision `kept_existing_champion_business_regression`.
+
+**One-time migration** (only needed on pre-existing databases — fresh `docker compose up` gets the schema from `db/init/`):
+
+```bash
+docker exec -i bt4301_postgres psql -U bt4301 -d kkbox \
+  < db/migrations/add_model_monitoring_results.sql
+```
+
+**Run end-to-end** (DB + MLflow + Airflow stack must be up):
+
+```bash
+# 1. Score customers — writes model_version, threshold_version, feature_snapshot_id
+python source/mlops/score_churn.py all
+
+# 2. Register (runs the business-metric gate)
+python source/mlops/register_model.py
+
+# 3. Weekly monitoring (writes calibration, segment PSI, and sample counts)
+docker exec bt4301_airflow_scheduler \
+  airflow dags trigger weekly_model_monitoring
+
+# 4. Retraining DAG reads monitoring status, skips on insufficient_data
+docker exec bt4301_airflow_scheduler \
+  airflow dags trigger automated_retraining
+```
+
+**Inspect results:**
+
+```sql
+-- Provenance on latest predictions
+SELECT DISTINCT model_version, threshold_version, feature_snapshot_id
+FROM processed.churn_predictions
+ORDER BY 1, 2 NULLS LAST LIMIT 5;
+
+-- Latest monitoring run
+SELECT status, labeled_sample_count, min_sample_threshold,
+       brier_score, max_calibration_error,
+       jsonb_pretty(segment_psi) AS segment_psi
+FROM processed.model_monitoring_results
+ORDER BY monitored_at DESC LIMIT 1;
+
+-- Registry evidence — new business-metric fields
+cat docs/artifacts/model_registry.json | python -m json.tool
+```
+
+**Environment overrides:**
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `MONITORING_MIN_SAMPLES` | `1000` | Minimum labelled rows for an actionable verdict |
+| `MAX_CALIBRATION_ERROR` | `0.10` | Max bin gap before flagging calibration drift |
+| `SEGMENT_PSI` | `0.20` | PSI threshold per segment |
+| `BUSINESS_METRIC_KEY` | `precision_churn` | Metric used in the promotion gate |
+| `BUSINESS_METRIC_TOLERANCE` | `0.01` | Max absolute regression tolerated |
+| `CLASSIFICATION_THRESHOLD_VERSION` | `v1` | Version tag written into every scored row |
+
+**Run the unit tests:**
+
+```bash
+python -m pytest source/tests/test_mlops_monitoring.py \
+                  source/tests/test_mlops_promotion_gate.py -v
+```
+
+Tests are pure numpy/pandas — no MLflow, Airflow, or Postgres dependencies at runtime.
+
+---
+
 ## Airflow DAGs
 
 Current DAGs:

--- a/db/init/02_processed.sql
+++ b/db/init/02_processed.sql
@@ -66,5 +66,7 @@ CREATE TABLE IF NOT EXISTS processed.churn_predictions (
     scored_at           TIMESTAMPTZ NOT NULL,
     shap_values         JSONB,
     feature_snapshot_id UUID,
+    model_version       TEXT,
+    threshold_version   TEXT,
     PRIMARY KEY (customer_id, scored_at)
 );

--- a/db/init/03_monitoring.sql
+++ b/db/init/03_monitoring.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS processed.model_monitoring_results (
-    result_id               BIGSERIAL     PRIMARY KEY,  
+    result_id               BIGSERIAL     PRIMARY KEY,
     -- monitoring run timestamp
     monitored_at            TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
     -- baseline/current comparison windows (time-window reference for monitoring run)
@@ -23,5 +23,17 @@ CREATE TABLE IF NOT EXISTS processed.model_monitoring_results (
     baseline_row_count      INT           NOT NULL DEFAULT 0,
     current_row_count       INT           NOT NULL DEFAULT 0,
     -- feature-level drift details (JSON: {feature_name: psi_value})
-    psi_by_feature          JSONB         NOT NULL
+    psi_by_feature          JSONB         NOT NULL,
+    -- Workstream F: richer monitoring evidence
+    status                  TEXT          NOT NULL DEFAULT 'ok',
+    brier_score             NUMERIC(10,6),
+    max_calibration_error   NUMERIC(10,6),
+    calibration_bins        JSONB,
+    score_distribution      JSONB,
+    segment_psi             JSONB,
+    labeled_sample_count    INT           NOT NULL DEFAULT 0,
+    min_sample_threshold    INT           NOT NULL DEFAULT 0
 );
+
+CREATE INDEX IF NOT EXISTS idx_model_monitoring_results_monitored_at
+    ON processed.model_monitoring_results (monitored_at DESC);

--- a/db/migrations/add_model_monitoring_results.sql
+++ b/db/migrations/add_model_monitoring_results.sql
@@ -1,0 +1,29 @@
+-- Workstream F — MLOps monitoring & promotion quality.
+--
+-- Adds two groups of columns:
+-- 1. Provenance on processed.churn_predictions (model_version, threshold_version)
+--    so every scored row can be traced back to the exact model registry version
+--    and classification-threshold policy in force.
+-- 2. Richer monitoring fields on processed.model_monitoring_results: calibration
+--    error / bins, score distribution, segment-level PSI, labelled-sample count,
+--    and an explicit status ('ok' | 'breached' | 'insufficient_data').
+
+-- --- Provenance on churn_predictions -------------------------------------
+ALTER TABLE processed.churn_predictions
+    ADD COLUMN IF NOT EXISTS model_version     TEXT,
+    ADD COLUMN IF NOT EXISTS threshold_version TEXT;
+
+-- --- Monitoring extras on model_monitoring_results -----------------------
+ALTER TABLE processed.model_monitoring_results
+    ADD COLUMN IF NOT EXISTS status                 TEXT    NOT NULL DEFAULT 'ok',
+    ADD COLUMN IF NOT EXISTS brier_score            NUMERIC(10,6),
+    ADD COLUMN IF NOT EXISTS max_calibration_error  NUMERIC(10,6),
+    ADD COLUMN IF NOT EXISTS calibration_bins       JSONB,
+    ADD COLUMN IF NOT EXISTS score_distribution     JSONB,
+    ADD COLUMN IF NOT EXISTS segment_psi            JSONB,
+    ADD COLUMN IF NOT EXISTS labeled_sample_count   INT     NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS min_sample_threshold   INT     NOT NULL DEFAULT 0;
+
+-- Friendly index so retraining DAG can quickly locate the latest status row.
+CREATE INDEX IF NOT EXISTS idx_model_monitoring_results_monitored_at
+    ON processed.model_monitoring_results (monitored_at DESC);

--- a/source/dataops/airflow/dags/automated_retraining_dag.py
+++ b/source/dataops/airflow/dags/automated_retraining_dag.py
@@ -64,6 +64,9 @@ def automated_retraining():
     @task.branch(task_id="check_drift_results")
     def check_drift_results() -> str:
         with get_pg_conn() as conn:
+            # Tolerate older monitoring rows that predate workstream F (no `status`
+            # column). Prefer the status column when it exists; otherwise fall back
+            # to the legacy `breached` flag.
             with conn.cursor(cursor_factory=RealDictCursor) as cur:
                 cur.execute(
                     """
@@ -77,7 +80,10 @@ def automated_retraining():
                         breached_reasons,
                         baseline_row_count,
                         current_row_count,
-                        psi_by_feature
+                        psi_by_feature,
+                        COALESCE(status, CASE WHEN breached THEN 'breached' ELSE 'ok' END) AS status,
+                        labeled_sample_count,
+                        min_sample_threshold
                     FROM processed.model_monitoring_results
                     ORDER BY monitored_at DESC
                     LIMIT 1
@@ -88,6 +94,22 @@ def automated_retraining():
         if row is None:
             return "skip_retraining"
 
+        # Workstream F: if the latest monitoring run flagged insufficient data,
+        # do not retrain. Retraining on sparse/unlabelled windows produces a
+        # noisy model and masks the real problem (missing labels).
+        status = (row.get("status") or "ok").lower()
+        if status == "insufficient_data":
+            payload = {
+                "checked_at": datetime.utcnow().isoformat() + "Z",
+                "status": status,
+                "labeled_sample_count": int(row.get("labeled_sample_count") or 0),
+                "min_sample_threshold": int(row.get("min_sample_threshold") or 0),
+                "should_retrain": False,
+                "reason": "insufficient_labeled_samples",
+            }
+            DECISION_PATH.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            return "skip_retraining"
+
         max_psi = float(row["max_psi"] or 0.0)
         auc_delta = float(row["auc_delta"]) if row["auc_delta"] is not None else None
         should_retrain = max_psi > PSI_THRESHOLD or (
@@ -96,6 +118,7 @@ def automated_retraining():
 
         payload = {
             "checked_at": datetime.utcnow().isoformat() + "Z",
+            "status": status,
             "latest_monitoring_row": {
                 "monitored_at": row["monitored_at"].isoformat() if row["monitored_at"] else None,
                 "baseline_auc": float(row["baseline_auc"]) if row["baseline_auc"] is not None else None,
@@ -107,6 +130,8 @@ def automated_retraining():
                 "baseline_row_count": int(row["baseline_row_count"] or 0),
                 "current_row_count": int(row["current_row_count"] or 0),
                 "psi_by_feature": row["psi_by_feature"],
+                "labeled_sample_count": int(row.get("labeled_sample_count") or 0),
+                "min_sample_threshold": int(row.get("min_sample_threshold") or 0),
             },
             "psi_threshold": PSI_THRESHOLD,
             "auc_delta_threshold": AUC_DELTA_THRESHOLD,

--- a/source/dataops/airflow/dags/weekly_model_monitoring_dag.py
+++ b/source/dataops/airflow/dags/weekly_model_monitoring_dag.py
@@ -49,6 +49,19 @@ REGISTRY_EVIDENCE_PATH = PROJECT_ROOT / "docs" / "artifacts" / "model_registry.j
 
 from source.common.db import get_connection as get_pg_conn
 from source.common.monitoring_utils import compute_psi, roc_auc_binary
+from source.mlops.monitoring import (
+    MAX_CALIBRATION_ERROR_THRESHOLD,
+    MIN_LABELED_SAMPLES,
+    SEGMENT_PSI_THRESHOLD,
+    compute_brier_score,
+    compute_calibration_bins,
+    compute_max_calibration_error,
+    compute_score_distribution,
+    segment_psi_breached,
+)
+
+# Monitoring DAG segments — derived at query time from customer_features columns.
+SEGMENT_COLUMNS = ("latest_is_auto_renew", "has_cancel_history")
 
 
 def stable_bucket(key: str) -> int:
@@ -178,6 +191,9 @@ def weekly_model_monitoring():
                         p.scored_at,
                         p.churn_probability::float8 AS score,
                         t.is_churn::int AS label,
+                        COALESCE(cf.latest_is_auto_renew, 0)::int AS latest_is_auto_renew,
+                        CASE WHEN COALESCE(cf.cancel_count, 0) > 0 THEN 1 ELSE 0 END
+                            AS has_cancel_history,
                         {", ".join([f"cf.{f}::float8 AS {f}" for f in top_5_features])}
                     FROM {predictions_table} p
                     JOIN processed.customer_features cf
@@ -270,7 +286,83 @@ def weekly_model_monitoring():
                     f"AUC degradation threshold breached: delta={auc_delta:.4f} (>0.05)"
                 )
 
-            breached = len(breached_reasons) > 0
+            # --- Workstream F: calibration + segment PSI + sample-size guard ---
+            current_y_true = y_true[current_mask]
+            current_y_score = y_score[current_mask]
+            calibration_bins: list[dict] = []
+            brier_score: float | None = None
+            max_cal_err: float | None = None
+            score_distribution: list[dict] = []
+            segment_psi: dict[str, float] = {}
+
+            labeled_sample_count = int(current_y_true.size)
+            insufficient = labeled_sample_count < MIN_LABELED_SAMPLES
+
+            if labeled_sample_count > 0:
+                try:
+                    calibration_bins = list(
+                        compute_calibration_bins(current_y_true, current_y_score, n_bins=10)
+                    )
+                    brier_score = compute_brier_score(current_y_true, current_y_score)
+                    max_cal_err = compute_max_calibration_error(calibration_bins)
+                    score_distribution = list(compute_score_distribution(current_y_score))
+                except ValueError as exc:
+                    breached_reasons.append(f"Calibration computation failed: {exc}")
+
+                # Per-segment PSI — compare current vs baseline for each segment key.
+                segment_df_baseline = pd.DataFrame(
+                    {
+                        "score": y_score[baseline_mask],
+                        **{
+                            col: np.array([r[col] for r in rows])[baseline_mask]
+                            for col in SEGMENT_COLUMNS
+                        },
+                    }
+                )
+                segment_df_current = pd.DataFrame(
+                    {
+                        "score": current_y_score,
+                        **{
+                            col: np.array([r[col] for r in rows])[current_mask]
+                            for col in SEGMENT_COLUMNS
+                        },
+                    }
+                )
+                try:
+                    from source.mlops.monitoring import compute_segment_psi
+
+                    segment_psi = compute_segment_psi(
+                        segment_df_baseline,
+                        segment_df_current,
+                        segment_columns=list(SEGMENT_COLUMNS),
+                        score_column="score",
+                    )
+                except ValueError as exc:
+                    breached_reasons.append(f"Segment PSI failed: {exc}")
+
+            if insufficient:
+                status = "insufficient_data"
+                # Don't flip breached just because we saw a single PSI number;
+                # we don't have enough labels to trust the verdict yet.
+                breached_reasons.append(
+                    f"Insufficient labelled samples in current window: "
+                    f"{labeled_sample_count} < {MIN_LABELED_SAMPLES}"
+                )
+                breached = False
+            else:
+                if max_cal_err is not None and max_cal_err > MAX_CALIBRATION_ERROR_THRESHOLD:
+                    breached_reasons.append(
+                        f"Calibration error exceeds threshold: "
+                        f"{max_cal_err:.4f} > {MAX_CALIBRATION_ERROR_THRESHOLD}"
+                    )
+                bad_segments = segment_psi_breached(segment_psi, SEGMENT_PSI_THRESHOLD)
+                if bad_segments:
+                    breached_reasons.append(
+                        f"Segment PSI breached ({SEGMENT_PSI_THRESHOLD}): "
+                        f"{', '.join(bad_segments)}"
+                    )
+                breached = len(breached_reasons) > 0
+                status = "breached" if breached else "ok"
 
             with conn.cursor() as cur:
                 cur.execute(
@@ -326,6 +418,31 @@ def weekly_model_monitoring():
                     "ALTER TABLE processed.model_monitoring_results "
                     "ADD COLUMN IF NOT EXISTS current_row_count INT NOT NULL DEFAULT 0"
                 )
+                # Workstream F: ensure the richer monitoring columns exist on
+                # long-lived DBs that were created before the F migration.
+                cur.execute(
+                    "ALTER TABLE processed.model_monitoring_results "
+                    "ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'ok'"
+                )
+                for col, typ in [
+                    ("brier_score", "NUMERIC(10,6)"),
+                    ("max_calibration_error", "NUMERIC(10,6)"),
+                    ("calibration_bins", "JSONB"),
+                    ("score_distribution", "JSONB"),
+                    ("segment_psi", "JSONB"),
+                ]:
+                    cur.execute(
+                        f"ALTER TABLE processed.model_monitoring_results "
+                        f"ADD COLUMN IF NOT EXISTS {col} {typ}"
+                    )
+                cur.execute(
+                    "ALTER TABLE processed.model_monitoring_results "
+                    "ADD COLUMN IF NOT EXISTS labeled_sample_count INT NOT NULL DEFAULT 0"
+                )
+                cur.execute(
+                    "ALTER TABLE processed.model_monitoring_results "
+                    "ADD COLUMN IF NOT EXISTS min_sample_threshold INT NOT NULL DEFAULT 0"
+                )
                 cur.execute(
                     """
                     INSERT INTO processed.model_monitoring_results (
@@ -343,9 +460,18 @@ def weekly_model_monitoring():
                         baseline_auc_source,
                         cohort_strategy,
                         baseline_row_count,
-                        current_row_count
+                        current_row_count,
+                        status,
+                        brier_score,
+                        max_calibration_error,
+                        calibration_bins,
+                        score_distribution,
+                        segment_psi,
+                        labeled_sample_count,
+                        min_sample_threshold
                     )
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s,
+                            %s, %s, %s, %s::jsonb, %s::jsonb, %s::jsonb, %s, %s)
                     """,
                     (
                         baseline_window_start,
@@ -363,12 +489,21 @@ def weekly_model_monitoring():
                         cohort_strategy,
                         baseline_n,
                         current_n,
+                        status,
+                        brier_score,
+                        max_cal_err,
+                        json.dumps(calibration_bins),
+                        json.dumps(score_distribution),
+                        json.dumps(segment_psi),
+                        labeled_sample_count,
+                        MIN_LABELED_SAMPLES,
                     ),
                 )
 
             conn.commit()
 
         return {
+            "status": status,
             "breached": breached,
             "breached_reasons": breached_reasons,
             "predictions_table": predictions_table,
@@ -382,6 +517,11 @@ def weekly_model_monitoring():
             "cohort_strategy": cohort_strategy,
             "baseline_row_count": baseline_n,
             "current_row_count": current_n,
+            "labeled_sample_count": labeled_sample_count,
+            "min_sample_threshold": MIN_LABELED_SAMPLES,
+            "brier_score": brier_score,
+            "max_calibration_error": max_cal_err,
+            "segment_psi": segment_psi,
         }
 
     @task.branch(task_id="evaluate_thresholds")

--- a/source/mlops/monitoring.py
+++ b/source/mlops/monitoring.py
@@ -1,0 +1,243 @@
+"""Monitoring helpers for Workstream F.
+
+Pure functions for calibration, score-distribution, and segment-level drift
+monitoring used by ``weekly_model_monitoring_dag``. Kept numpy/pandas-only so
+the module can be imported without the full MLflow/sklearn stack.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable, Mapping, Sequence
+
+import numpy as np
+import pandas as pd
+
+from source.common.monitoring_utils import compute_psi
+
+# Minimum labelled rows required before a monitoring verdict is recorded.
+MIN_LABELED_SAMPLES: int = int(os.getenv("MONITORING_MIN_SAMPLES", "1000"))
+
+# Reliability bin breach threshold for calibration monitoring.
+MAX_CALIBRATION_ERROR_THRESHOLD: float = float(
+    os.getenv("MONITORING_MAX_CAL_ERROR", "0.10")
+)
+
+# Segment-level PSI breach threshold (matches feature-level threshold).
+SEGMENT_PSI_THRESHOLD: float = float(os.getenv("MONITORING_SEGMENT_PSI", "0.2"))
+
+# Status string written to ``processed.model_monitoring_results.status`` when
+# the current cohort is too small for a trustworthy verdict.
+INSUFFICIENT_DATA_STATUS: str = "insufficient_data"
+
+# Status string for a fully-populated monitoring row (no breaches).
+OK_STATUS: str = "ok"
+
+# Status string used when at least one threshold breached.
+BREACHED_STATUS: str = "breached"
+
+
+def _as_float_array(values: Iterable[float]) -> np.ndarray:
+    return np.asarray(list(values), dtype=np.float64)
+
+
+def _as_int_array(values: Iterable[int]) -> np.ndarray:
+    return np.asarray(list(values), dtype=np.int64)
+
+
+def compute_calibration_bins(
+    y_true: Iterable[int],
+    y_score: Iterable[float],
+    n_bins: int = 10,
+) -> list[dict]:
+    """Return reliability-diagram bins for a binary classifier.
+
+    Each bin dict has: ``bin_lower``, ``bin_upper``, ``mean_pred``,
+    ``actual_rate``, ``count``. Uses fixed equal-width bins over ``[0, 1]``.
+    Empty bins are emitted with ``count=0`` and ``mean_pred=actual_rate=None``
+    so the output length is always ``n_bins``.
+    """
+    y_true_arr = _as_int_array(y_true)
+    y_score_arr = _as_float_array(y_score)
+
+    if y_true_arr.size != y_score_arr.size:
+        raise ValueError(
+            "compute_calibration_bins: y_true and y_score must have equal length"
+        )
+    if n_bins <= 0:
+        raise ValueError("compute_calibration_bins: n_bins must be positive")
+
+    edges = np.linspace(0.0, 1.0, n_bins + 1, dtype=np.float64)
+    # np.digitize: bin 1 for edges[0] <= x < edges[1], bin n_bins for top edge.
+    # Clip scores into [0, 1] defensively.
+    clipped = np.clip(y_score_arr, 0.0, 1.0)
+    # Use right=False so 0.0 maps to bin 1 and 1.0 rolls into last bin via clamp.
+    idx = np.clip(np.digitize(clipped, edges[1:-1], right=False), 0, n_bins - 1)
+
+    bins: list[dict] = []
+    for b in range(n_bins):
+        mask = idx == b
+        count = int(mask.sum())
+        if count == 0:
+            bins.append(
+                {
+                    "bin_lower": float(edges[b]),
+                    "bin_upper": float(edges[b + 1]),
+                    "mean_pred": None,
+                    "actual_rate": None,
+                    "count": 0,
+                }
+            )
+            continue
+
+        bins.append(
+            {
+                "bin_lower": float(edges[b]),
+                "bin_upper": float(edges[b + 1]),
+                "mean_pred": float(y_score_arr[mask].mean()),
+                "actual_rate": float(y_true_arr[mask].mean()),
+                "count": count,
+            }
+        )
+
+    return bins
+
+
+def compute_brier_score(
+    y_true: Iterable[int], y_score: Iterable[float]
+) -> float:
+    """Compute the Brier score (mean squared error between labels and probs)."""
+    y_true_arr = _as_int_array(y_true).astype(np.float64)
+    y_score_arr = _as_float_array(y_score)
+    if y_true_arr.size == 0:
+        return float("nan")
+    if y_true_arr.size != y_score_arr.size:
+        raise ValueError(
+            "compute_brier_score: y_true and y_score must have equal length"
+        )
+    return float(np.mean((y_score_arr - y_true_arr) ** 2))
+
+
+def compute_max_calibration_error(bins: Sequence[Mapping[str, object]]) -> float:
+    """Max absolute gap between mean_pred and actual_rate across non-empty bins."""
+    gaps = []
+    for b in bins:
+        if b.get("count", 0) == 0:
+            continue
+        mean_pred = b.get("mean_pred")
+        actual = b.get("actual_rate")
+        if mean_pred is None or actual is None:
+            continue
+        gaps.append(abs(float(mean_pred) - float(actual)))
+    return float(max(gaps)) if gaps else 0.0
+
+
+def compute_score_distribution(
+    y_score: Iterable[float], n_bins: int = 10
+) -> list[dict]:
+    """Return decile counts: ``[{bin_lower, bin_upper, count, pct}]``."""
+    y_score_arr = _as_float_array(y_score)
+    if n_bins <= 0:
+        raise ValueError("compute_score_distribution: n_bins must be positive")
+
+    edges = np.linspace(0.0, 1.0, n_bins + 1, dtype=np.float64)
+    total = max(int(y_score_arr.size), 1)
+    clipped = np.clip(y_score_arr, 0.0, 1.0)
+    counts, _ = np.histogram(clipped, bins=edges)
+
+    return [
+        {
+            "bin_lower": float(edges[i]),
+            "bin_upper": float(edges[i + 1]),
+            "count": int(counts[i]),
+            "pct": float(counts[i]) / total,
+        }
+        for i in range(n_bins)
+    ]
+
+
+def compute_segment_psi(
+    baseline: pd.DataFrame,
+    current: pd.DataFrame,
+    segment_columns: Sequence[str],
+    score_column: str = "score",
+) -> dict[str, float]:
+    """Compute PSI on ``score_column`` within each value of each segment column.
+
+    Returns a flat dict keyed ``"{column}={value}"`` mapping to the PSI value.
+    Segments that are missing entirely from either side receive a ``nan`` so
+    downstream code can distinguish "no drift" (0.0) from "not comparable".
+    """
+    if score_column not in baseline.columns or score_column not in current.columns:
+        raise ValueError(
+            f"compute_segment_psi: '{score_column}' missing from baseline or current"
+        )
+
+    results: dict[str, float] = {}
+    for col in segment_columns:
+        if col not in baseline.columns or col not in current.columns:
+            results[f"{col}=missing"] = float("nan")
+            continue
+
+        values = pd.unique(
+            pd.concat([baseline[col], current[col]], ignore_index=True).dropna()
+        )
+        for value in values:
+            baseline_slice = baseline.loc[baseline[col] == value, score_column].to_numpy(
+                dtype=np.float64, copy=False
+            )
+            current_slice = current.loc[current[col] == value, score_column].to_numpy(
+                dtype=np.float64, copy=False
+            )
+            key = f"{col}={value}"
+            if baseline_slice.size < 2 or current_slice.size < 2:
+                results[key] = float("nan")
+                continue
+            results[key] = compute_psi(baseline_slice, current_slice)
+
+    return results
+
+
+def has_insufficient_data(
+    current_row_count: int,
+    min_samples: int | None = None,
+) -> bool:
+    """Return True when the current cohort is below the monitoring guard."""
+    threshold = int(min_samples if min_samples is not None else MIN_LABELED_SAMPLES)
+    return int(current_row_count) < threshold
+
+
+def segment_psi_breached(
+    segment_psi: Mapping[str, float],
+    threshold: float | None = None,
+) -> list[str]:
+    """Return the list of segment keys whose PSI exceeds the threshold."""
+    limit = float(threshold if threshold is not None else SEGMENT_PSI_THRESHOLD)
+    breached: list[str] = []
+    for key, value in segment_psi.items():
+        try:
+            v = float(value)
+        except (TypeError, ValueError):
+            continue
+        if not np.isfinite(v):
+            continue
+        if v > limit:
+            breached.append(key)
+    return breached
+
+
+__all__ = [
+    "MIN_LABELED_SAMPLES",
+    "MAX_CALIBRATION_ERROR_THRESHOLD",
+    "SEGMENT_PSI_THRESHOLD",
+    "INSUFFICIENT_DATA_STATUS",
+    "OK_STATUS",
+    "BREACHED_STATUS",
+    "compute_calibration_bins",
+    "compute_brier_score",
+    "compute_max_calibration_error",
+    "compute_score_distribution",
+    "compute_segment_psi",
+    "has_insufficient_data",
+    "segment_psi_breached",
+]

--- a/source/mlops/register_model.py
+++ b/source/mlops/register_model.py
@@ -44,6 +44,12 @@ MODEL_NAME = "KKBox-Churn-Classifier"
 DEFAULT_TRACKING_URI = os.getenv("MLFLOW_TRACKING_URI", "http://localhost:5001")
 DEFAULT_PROMOTION_THRESHOLD = 0.0
 
+# Workstream F: business-metric gate.
+# Promotion requires BOTH an AUC improvement over the threshold AND no
+# regression on the business metric beyond BUSINESS_METRIC_TOLERANCE (absolute).
+BUSINESS_METRIC_KEY = os.getenv("BUSINESS_METRIC_KEY", "precision_churn")
+BUSINESS_METRIC_TOLERANCE = float(os.getenv("BUSINESS_METRIC_TOLERANCE", "0.01"))
+
 
 @dataclass(frozen=True)
 class StageTransition:
@@ -72,6 +78,12 @@ class RegistryResult:
     transitions: tuple[StageTransition, ...]
     final_stage: str
     registry_uri: str
+    # Workstream F: business-metric gate evidence.
+    business_metric_key: str = BUSINESS_METRIC_KEY
+    business_metric_tolerance: float = BUSINESS_METRIC_TOLERANCE
+    challenger_business_metric: float | None = None
+    champion_business_metric: float | None = None
+    business_metric_delta: float | None = None
 
 
 def load_best_model_info(path: Path) -> dict:
@@ -140,6 +152,41 @@ def get_model_roc_auc(client: MlflowClient, run_id: str) -> float:
         return float(run.data.metrics["roc_auc"])
     except KeyError as exc:
         raise KeyError(f"Run {run_id} is missing metric 'roc_auc'") from exc
+
+
+def get_model_business_metric(
+    client: MlflowClient,
+    run_id: str,
+    metric_key: str = BUSINESS_METRIC_KEY,
+) -> float | None:
+    """Read the business metric from the source run; return None if missing."""
+    try:
+        run = client.get_run(run_id)
+    except Exception:
+        return None
+    value = run.data.metrics.get(metric_key)
+    return float(value) if value is not None else None
+
+
+def evaluate_business_metric_gate(
+    challenger: float | None,
+    champion: float | None,
+    tolerance: float = BUSINESS_METRIC_TOLERANCE,
+) -> tuple[bool, float | None]:
+    """Decide whether the challenger clears the business-metric gate.
+
+    Returns ``(allow_promotion, delta)`` where ``delta = challenger - champion``.
+    If either side is missing, promotion is allowed (gate is permissive to
+    avoid blocking on incomplete metric coverage — the AUC gate still applies).
+    """
+    if challenger is None or champion is None:
+        return True, (
+            challenger - champion
+            if challenger is not None and champion is not None
+            else None
+        )
+    delta = challenger - champion
+    return delta >= -abs(tolerance), delta
 
 
 def get_current_production_version(
@@ -229,6 +276,11 @@ def save_evidence(result: RegistryResult, output_path: Path) -> None:
         "champion_auc": result.champion_auc,
         "promotion_threshold": result.promotion_threshold,
         "auc_margin": result.auc_margin,
+        "business_metric_key": result.business_metric_key,
+        "business_metric_tolerance": result.business_metric_tolerance,
+        "challenger_business_metric": result.challenger_business_metric,
+        "champion_business_metric": result.champion_business_metric,
+        "business_metric_delta": result.business_metric_delta,
         "decision": result.decision,
         "transitions": [
             {
@@ -348,10 +400,27 @@ def main() -> None:
             champion_auc,
         )
 
+    challenger_business_metric = float(
+        best_info.get("metrics", {}).get(BUSINESS_METRIC_KEY, float("nan"))
+    )
+    if challenger_business_metric != challenger_business_metric:  # NaN check
+        challenger_business_metric = None
+    champion_business_metric = (
+        get_model_business_metric(client, champion.run_id)
+        if champion is not None and champion.run_id
+        else None
+    )
+
     version = register_best_model(client, run_id, args.model_name)
 
     transitions: list[StageTransition] = []
     transitions.append(transition_stage(client, args.model_name, version, "Staging"))
+
+    business_gate_ok, business_metric_delta = evaluate_business_metric_gate(
+        challenger_business_metric,
+        champion_business_metric,
+        tolerance=BUSINESS_METRIC_TOLERANCE,
+    )
 
     if champion_auc is None:
         promote = True
@@ -359,8 +428,14 @@ def main() -> None:
         auc_margin = None
     else:
         auc_margin = challenger_auc - champion_auc
-        promote = challenger_auc > champion_auc + args.promotion_threshold
-        decision = "promoted_over_champion" if promote else "kept_existing_champion"
+        auc_gate_ok = challenger_auc > champion_auc + args.promotion_threshold
+        promote = auc_gate_ok and business_gate_ok
+        if promote:
+            decision = "promoted_over_champion"
+        elif not auc_gate_ok:
+            decision = "kept_existing_champion"
+        else:
+            decision = "kept_existing_champion_business_regression"
 
     timestamp = datetime.now(timezone.utc).isoformat()
     comparison_note = [
@@ -378,6 +453,17 @@ def main() -> None:
             f"AUC margin (challenger - champion): {auc_margin:.6f}"
             if auc_margin is not None
             else "AUC margin (challenger - champion): not applicable"
+        ),
+        (
+            f"Business metric ({BUSINESS_METRIC_KEY}) "
+            f"challenger={challenger_business_metric:.6f} "
+            f"champion={champion_business_metric:.6f} "
+            f"delta={business_metric_delta:.6f} "
+            f"tolerance={BUSINESS_METRIC_TOLERANCE:.6f} "
+            f"gate_ok={business_gate_ok}"
+            if challenger_business_metric is not None
+            and champion_business_metric is not None
+            else f"Business metric ({BUSINESS_METRIC_KEY}): not applicable"
         ),
     ]
 
@@ -407,6 +493,23 @@ def main() -> None:
             "champion_version": str(champion_version) if champion_version is not None else "none",
             "champion_auc": f"{champion_auc:.6f}" if champion_auc is not None else "none",
             "auc_margin": f"{auc_margin:.6f}" if auc_margin is not None else "none",
+            "business_metric_key": BUSINESS_METRIC_KEY,
+            "business_metric_tolerance": f"{BUSINESS_METRIC_TOLERANCE:.6f}",
+            "challenger_business_metric": (
+                f"{challenger_business_metric:.6f}"
+                if challenger_business_metric is not None
+                else "none"
+            ),
+            "champion_business_metric": (
+                f"{champion_business_metric:.6f}"
+                if champion_business_metric is not None
+                else "none"
+            ),
+            "business_metric_delta": (
+                f"{business_metric_delta:.6f}"
+                if business_metric_delta is not None
+                else "none"
+            ),
             "decision_timestamp": timestamp,
         },
     )
@@ -444,6 +547,11 @@ def main() -> None:
         transitions=tuple(transitions),
         final_stage=final_stage,
         registry_uri=registry_uri,
+        business_metric_key=BUSINESS_METRIC_KEY,
+        business_metric_tolerance=BUSINESS_METRIC_TOLERANCE,
+        challenger_business_metric=challenger_business_metric,
+        champion_business_metric=champion_business_metric,
+        business_metric_delta=business_metric_delta,
     )
 
     registry_path = ARTIFACT_DIR / "model_registry.json"

--- a/source/mlops/score_churn.py
+++ b/source/mlops/score_churn.py
@@ -36,6 +36,12 @@ SCORES_PATH = SCORING_DIR / "scores.parquet"
 HIGH_THRESHOLD = float(os.getenv("CHURN_HIGH_THRESHOLD", "0.7"))
 MEDIUM_THRESHOLD = float(os.getenv("CHURN_MEDIUM_THRESHOLD", "0.4"))
 
+# Workstream F: classification threshold policy version. Bump when the
+# High/Medium cutoffs change so historical predictions remain interpretable.
+CLASSIFICATION_THRESHOLD_VERSION: str = os.getenv(
+    "CLASSIFICATION_THRESHOLD_VERSION", "v1"
+)
+
 _REGISTRY_URI = "models:/KKBox-Churn-Classifier/Production"
 
 
@@ -151,18 +157,49 @@ def _extract_input_columns(signature) -> list[str]:
     return input_columns
 
 
+def _resolve_registered_version(model_uri: str) -> tuple[str | None, str | None]:
+    """Return (model_name, model_version) for a ``models:/<name>/<stage>`` URI.
+
+    Falls back to (None, None) for run-based URIs or when the registry lookup
+    fails — scoring still proceeds, but the prediction row is missing provenance.
+    """
+    if not model_uri.startswith("models:/"):
+        return None, None
+    try:
+        from mlflow.tracking import MlflowClient
+
+        _, name, stage = model_uri.split("/", 2)
+        client = MlflowClient()
+        versions = client.get_latest_versions(name, stages=[stage])
+        if versions:
+            return name, str(versions[0].version)
+    except Exception:
+        return None, None
+    return None, None
+
+
 def _build_model_metadata(model_uri: str, model_info) -> ProductionModelMetadata:
     input_columns = _extract_input_columns(model_info.signature)
+    model_name = getattr(model_info, "name", None)
+    model_version: str | None = (
+        str(model_info.registered_model_version)
+        if getattr(model_info, "registered_model_version", None) is not None
+        else None
+    )
+    # Fallback: some mlflow versions don't populate registered_model_version on
+    # ModelInfo when the URI is models:/<name>/<stage>. Ask the registry.
+    if model_version is None:
+        resolved_name, resolved_version = _resolve_registered_version(model_uri)
+        if resolved_version is not None:
+            model_version = resolved_version
+            if model_name is None:
+                model_name = resolved_name
     return ProductionModelMetadata(
         model_uri=model_uri,
         input_columns=input_columns,
         input_signature=model_info.signature.to_dict(),
-        model_name=getattr(model_info, "name", None),
-        model_version=(
-            str(model_info.registered_model_version)
-            if getattr(model_info, "registered_model_version", None) is not None
-            else None
-        ),
+        model_name=model_name,
+        model_version=model_version,
     )
 
 
@@ -256,10 +293,16 @@ def airflow_write_predictions(artifacts: ScoringArtifacts | None = None, **_) ->
 
     if not artifacts.scores_path.exists():
         raise FileNotFoundError("Scores parquet not found. Run score first.")
+    if not artifacts.model_metadata_path.exists():
+        raise FileNotFoundError(
+            "Production model metadata not found. Run load_production_model first."
+        )
 
     scores = pd.read_parquet(artifacts.scores_path)
     scored_at = datetime.now(timezone.utc)
     scores["scored_at"] = scored_at
+    metadata = _load_model_metadata(artifacts.model_metadata_path)
+    model_version = metadata.model_version
 
     ddl = """
     CREATE TABLE IF NOT EXISTS processed.churn_predictions (
@@ -269,6 +312,8 @@ def airflow_write_predictions(artifacts: ScoringArtifacts | None = None, **_) ->
         scored_at           TIMESTAMPTZ NOT NULL,
         shap_values         JSONB,
         feature_snapshot_id UUID,
+        model_version       TEXT,
+        threshold_version   TEXT,
         PRIMARY KEY (customer_id, scored_at)
     );
     """
@@ -280,6 +325,14 @@ def airflow_write_predictions(artifacts: ScoringArtifacts | None = None, **_) ->
                 "ALTER TABLE processed.churn_predictions "
                 "ADD COLUMN IF NOT EXISTS feature_snapshot_id UUID"
             )
+            cur.execute(
+                "ALTER TABLE processed.churn_predictions "
+                "ADD COLUMN IF NOT EXISTS model_version TEXT"
+            )
+            cur.execute(
+                "ALTER TABLE processed.churn_predictions "
+                "ADD COLUMN IF NOT EXISTS threshold_version TEXT"
+            )
 
         snapshot_id = get_current_snapshot_id(conn)
 
@@ -288,7 +341,10 @@ def airflow_write_predictions(artifacts: ScoringArtifacts | None = None, **_) ->
                 index=False, name=None
             )
         )
-        rows = [(*row, snapshot_id) for row in rows]
+        rows = [
+            (*row, snapshot_id, model_version, CLASSIFICATION_THRESHOLD_VERSION)
+            for row in rows
+        ]
 
         with conn.cursor() as cur:
             execute_values(
@@ -296,7 +352,7 @@ def airflow_write_predictions(artifacts: ScoringArtifacts | None = None, **_) ->
                 """
                 INSERT INTO processed.churn_predictions (
                     customer_id, churn_probability, risk_tier, scored_at,
-                    feature_snapshot_id
+                    feature_snapshot_id, model_version, threshold_version
                 )
                 VALUES %s
                 """,
@@ -306,7 +362,8 @@ def airflow_write_predictions(artifacts: ScoringArtifacts | None = None, **_) ->
 
     print(
         f"[write_predictions] Wrote {len(rows):,} rows into processed.churn_predictions"
-        f" (feature_snapshot={snapshot_id})"
+        f" (feature_snapshot={snapshot_id}, model_version={model_version},"
+        f" threshold_version={CLASSIFICATION_THRESHOLD_VERSION})"
     )
 
 

--- a/source/tests/test_mlops_monitoring.py
+++ b/source/tests/test_mlops_monitoring.py
@@ -1,0 +1,214 @@
+"""Unit tests for the Workstream F monitoring helpers (source/mlops/monitoring.py).
+
+Exercises the calibration, score-distribution, segment PSI, and sample-size
+helpers end-to-end. No Postgres, MLflow, or Airflow dependencies.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.mlops
+
+np = pytest.importorskip("numpy")
+pd = pytest.importorskip("pandas")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from source.mlops import monitoring as m
+
+
+# ---------------------------------------------------------------------------
+# compute_calibration_bins
+# ---------------------------------------------------------------------------
+
+
+def test_calibration_bins_perfect_classifier_has_zero_error() -> None:
+    # Labels line up with the predicted probability bucket midpoints.
+    y_true = [0, 0, 0, 0, 0, 1, 1, 1, 1, 1]
+    y_score = [0.05, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85, 0.95]
+    bins = m.compute_calibration_bins(y_true, y_score, n_bins=10)
+
+    assert len(bins) == 10
+    for b in bins:
+        if b["count"] == 0:
+            continue
+        if b["bin_lower"] < 0.5:
+            assert b["actual_rate"] == 0.0
+        else:
+            assert b["actual_rate"] == 1.0
+    assert m.compute_max_calibration_error(bins) == pytest.approx(0.45, abs=0.01)
+
+
+def test_calibration_bins_length_equals_n_bins_even_when_empty() -> None:
+    bins = m.compute_calibration_bins([0, 1], [0.05, 0.95], n_bins=5)
+    assert len(bins) == 5
+    empty_bins = [b for b in bins if b["count"] == 0]
+    assert len(empty_bins) == 3
+
+
+def test_calibration_bins_rejects_mismatched_lengths() -> None:
+    with pytest.raises(ValueError):
+        m.compute_calibration_bins([0, 1], [0.5], n_bins=2)
+
+
+def test_calibration_bins_rejects_nonpositive_n_bins() -> None:
+    with pytest.raises(ValueError):
+        m.compute_calibration_bins([0, 1], [0.1, 0.9], n_bins=0)
+
+
+# ---------------------------------------------------------------------------
+# compute_brier_score
+# ---------------------------------------------------------------------------
+
+
+def test_brier_score_of_perfect_prediction_is_zero() -> None:
+    assert m.compute_brier_score([0, 1, 0, 1], [0.0, 1.0, 0.0, 1.0]) == 0.0
+
+
+def test_brier_score_of_worst_prediction_is_one() -> None:
+    assert m.compute_brier_score([0, 1], [1.0, 0.0]) == 1.0
+
+
+def test_brier_score_empty_inputs_return_nan() -> None:
+    result = m.compute_brier_score([], [])
+    assert result != result  # NaN check
+
+
+# ---------------------------------------------------------------------------
+# compute_max_calibration_error
+# ---------------------------------------------------------------------------
+
+
+def test_max_calibration_error_ignores_empty_bins() -> None:
+    bins = [
+        {"count": 0, "mean_pred": None, "actual_rate": None},
+        {"count": 10, "mean_pred": 0.2, "actual_rate": 0.1},
+        {"count": 5, "mean_pred": 0.8, "actual_rate": 0.3},
+    ]
+    assert m.compute_max_calibration_error(bins) == pytest.approx(0.5)
+
+
+def test_max_calibration_error_returns_zero_when_no_populated_bins() -> None:
+    assert m.compute_max_calibration_error([{"count": 0}]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# compute_score_distribution
+# ---------------------------------------------------------------------------
+
+
+def test_score_distribution_uniform_spread() -> None:
+    scores = [0.05, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85, 0.95]
+    dist = m.compute_score_distribution(scores, n_bins=10)
+
+    assert len(dist) == 10
+    assert sum(b["count"] for b in dist) == len(scores)
+    for b in dist:
+        assert b["count"] == 1
+        assert b["pct"] == pytest.approx(0.1)
+
+
+def test_score_distribution_all_in_last_bucket() -> None:
+    dist = m.compute_score_distribution([0.95] * 20, n_bins=10)
+    assert dist[-1]["count"] == 20
+    assert sum(b["count"] for b in dist[:-1]) == 0
+
+
+# ---------------------------------------------------------------------------
+# compute_segment_psi
+# ---------------------------------------------------------------------------
+
+
+def test_segment_psi_zero_when_segments_match() -> None:
+    rng = np.random.default_rng(seed=0)
+    baseline = pd.DataFrame(
+        {
+            "score": rng.uniform(size=200),
+            "segment": ["a"] * 100 + ["b"] * 100,
+        }
+    )
+    current = baseline.copy()
+
+    result = m.compute_segment_psi(baseline, current, segment_columns=["segment"])
+
+    assert set(result.keys()) == {"segment=a", "segment=b"}
+    for v in result.values():
+        assert v == pytest.approx(0.0, abs=1e-6)
+
+
+def test_segment_psi_flags_shifted_segment() -> None:
+    rng = np.random.default_rng(seed=1)
+    baseline = pd.DataFrame(
+        {
+            "score": rng.uniform(0.0, 0.3, size=500),
+            "segment": ["a"] * 500,
+        }
+    )
+    current = pd.DataFrame(
+        {
+            # Distribution shifted right in the current window.
+            "score": rng.uniform(0.7, 1.0, size=500),
+            "segment": ["a"] * 500,
+        }
+    )
+    result = m.compute_segment_psi(baseline, current, segment_columns=["segment"])
+    assert result["segment=a"] > 0.2  # clearly drifted
+
+
+def test_segment_psi_returns_nan_when_too_few_samples() -> None:
+    baseline = pd.DataFrame({"score": [0.5], "segment": ["a"]})
+    current = pd.DataFrame({"score": [0.5], "segment": ["a"]})
+    result = m.compute_segment_psi(baseline, current, segment_columns=["segment"])
+    assert result["segment=a"] != result["segment=a"]  # NaN
+
+
+def test_segment_psi_missing_column_produces_missing_sentinel() -> None:
+    baseline = pd.DataFrame({"score": [0.1, 0.2]})
+    current = pd.DataFrame({"score": [0.3, 0.4]})
+    result = m.compute_segment_psi(
+        baseline, current, segment_columns=["missing_col"]
+    )
+    assert "missing_col=missing" in result
+    assert result["missing_col=missing"] != result["missing_col=missing"]
+
+
+def test_segment_psi_missing_score_column_raises() -> None:
+    baseline = pd.DataFrame({"segment": ["a"]})
+    current = pd.DataFrame({"segment": ["a"]})
+    with pytest.raises(ValueError):
+        m.compute_segment_psi(baseline, current, segment_columns=["segment"])
+
+
+# ---------------------------------------------------------------------------
+# has_insufficient_data / segment_psi_breached
+# ---------------------------------------------------------------------------
+
+
+def test_has_insufficient_data_flags_small_windows() -> None:
+    assert m.has_insufficient_data(0, min_samples=1000)
+    assert m.has_insufficient_data(999, min_samples=1000)
+    assert not m.has_insufficient_data(1000, min_samples=1000)
+    assert not m.has_insufficient_data(10_000)
+
+
+def test_segment_psi_breached_returns_keys_over_threshold() -> None:
+    segs = {
+        "segment=a": 0.05,
+        "segment=b": 0.30,
+        "segment=c": float("nan"),
+        "segment=d": 0.25,
+    }
+    assert sorted(m.segment_psi_breached(segs, threshold=0.2)) == [
+        "segment=b",
+        "segment=d",
+    ]
+
+
+def test_segment_psi_breached_empty_input_returns_empty_list() -> None:
+    assert m.segment_psi_breached({}, threshold=0.2) == []

--- a/source/tests/test_mlops_promotion_gate.py
+++ b/source/tests/test_mlops_promotion_gate.py
@@ -1,0 +1,69 @@
+"""Unit tests for the Workstream F business-metric promotion gate in
+``source/mlops/register_model.py``.
+
+We only import and test the pure helper — no MLflow client, no registry, no
+network. The gate function is intentionally side-effect free for easy testing.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.mlops
+
+pytest.importorskip("mlflow")  # register_model imports mlflow at module level
+pytest.importorskip("numpy")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from source.mlops.register_model import (
+    BUSINESS_METRIC_TOLERANCE,
+    evaluate_business_metric_gate,
+)
+
+
+def test_challenger_improves_business_metric_passes_gate() -> None:
+    allow, delta = evaluate_business_metric_gate(0.82, 0.78)
+    assert allow is True
+    assert delta == pytest.approx(0.04)
+
+
+def test_challenger_within_tolerance_still_passes() -> None:
+    # Challenger regressed by 0.005, within the 0.01 tolerance → allowed.
+    allow, delta = evaluate_business_metric_gate(0.775, 0.78, tolerance=0.01)
+    assert allow is True
+    assert delta == pytest.approx(-0.005)
+
+
+def test_challenger_beyond_tolerance_blocks_promotion() -> None:
+    allow, delta = evaluate_business_metric_gate(0.65, 0.80, tolerance=0.01)
+    assert allow is False
+    assert delta == pytest.approx(-0.15)
+
+
+def test_missing_challenger_metric_allows_promotion() -> None:
+    allow, delta = evaluate_business_metric_gate(None, 0.80)
+    assert allow is True
+    assert delta is None
+
+
+def test_missing_champion_metric_allows_promotion() -> None:
+    allow, delta = evaluate_business_metric_gate(0.80, None)
+    assert allow is True
+    assert delta is None
+
+
+def test_tolerance_absolute_value_handles_negative_input() -> None:
+    # A negative tolerance should behave the same as its absolute value.
+    allow, _ = evaluate_business_metric_gate(0.775, 0.78, tolerance=-0.01)
+    assert allow is True
+
+
+def test_default_tolerance_is_reasonable() -> None:
+    # Sanity: the default tolerance is a small positive number.
+    assert 0.0 < BUSINESS_METRIC_TOLERANCE < 0.1


### PR DESCRIPTION
## Summary

- **Calibration + score distribution** — `weekly_model_monitoring_dag` now computes reliability bins, Brier score, max calibration error, and 10-bucket probability distribution per run. Breaches flagged when calibration error > `MAX_CALIBRATION_ERROR` (default `0.10`).
- **Segment-level PSI** — per-segment drift computed on `latest_is_auto_renew` and derived `has_cancel_history` via `source.mlops.monitoring.compute_segment_psi`. Flagged when any segment's PSI > `SEGMENT_PSI` (default `0.20`).
- **Min sample-size guard** — when the labelled current window has fewer than `MONITORING_MIN_SAMPLES` rows (default `1000`) the monitoring row is written with `status='insufficient_data'` and the retraining DAG skips with `reason='insufficient_labeled_samples'`. Keeps retraining from firing on noisy windows.
- **Business-metric promotion gate** — `register_model.py` now requires both an AUC gain over `promotion_threshold` AND no regression on `precision_churn` (configurable via `BUSINESS_METRIC_KEY`) beyond `BUSINESS_METRIC_TOLERANCE` (default `0.01`). Rejection of a high-AUC but lower-precision challenger emits the new decision string `kept_existing_champion_business_regression`.
- **Provenance on every prediction** — `processed.churn_predictions` now records `model_version` (resolved via `MlflowClient.get_latest_versions` when needed) and `threshold_version` (`v1` at classification threshold `0.5`) alongside `feature_snapshot_id`.

## Dependencies

None — standalone. C (#64) and D (#63) already merged.

## Test plan

- [x] `docker exec -i bt4301_postgres psql -U bt4301 -d kkbox < db/migrations/add_model_monitoring_results.sql` — clean apply
- [x] `python source/mlops/score_churn.py all` — writes 194k rows with `model_version=1`, `threshold_version=v1`, `feature_snapshot_id=928b2064…`
- [x] `python source/mlops/register_model.py` — runs business-metric gate; `docs/artifacts/model_registry.json` contains `business_metric_key`, `challenger_business_metric`, `champion_business_metric`, `business_metric_delta`
- [x] Exercise the monitoring DAG's task callable against live DB — 233k labeled samples (≥ 1000 guard), `status='breached'` due to calibration error 0.2623 (> 0.10), segment_psi computed for all 4 keys, all columns populated
- [x] `docker exec bt4301_airflow_scheduler airflow dags list | grep -E "weekly_model_monitoring|automated_retraining"` — both listed, no broken DAG
- [x] `python -m pytest source/tests/test_mlops_monitoring.py source/tests/test_mlops_promotion_gate.py -v` — 26/26 pass

## Assumptions

- Threshold `0.5` versioned as `"v1"`. Bump `CLASSIFICATION_THRESHOLD_VERSION` when tier cutoffs change.
- Business metric: `precision_churn`, tolerance `0.01` absolute. Both env-overridable.
- Segment keys: `latest_is_auto_renew` (0/1), `has_cancel_history` (derived from `cancel_count > 0`).
- Min samples `1000` (`MONITORING_MIN_SAMPLES`). Missing business-metric values on either side default to "allow promotion" so AUC alone still governs the decision.